### PR TITLE
added -D_DARWIN_C_SOURCE to CFLAGS (gnu) in configure file.

### DIFF
--- a/configure
+++ b/configure
@@ -195,7 +195,7 @@ function defaultflags
             if [ "x$AR"        = "x" ]; then AR='ar'; fi
             if [ "x$CXXFLAGS"  = "x" ]; then CXXFLAGS='-fopenmp -O3'; fi
             if [ "x$NVCCFLAGS" = "x" ]; then NVCCLAGS=''; fi
-            if [ "x$DEFS"      = "x" ]; then DEFS='-D_POSIX_C_SOURCE=200112L -D__STDC_LIMIT_MACROS'; fi
+            if [ "x$DEFS"      = "x" ]; then DEFS='-D_POSIX_C_SOURCE=200112L -D__STDC_LIMIT_MACROS -D_DARWIN_C_SOURCE'; fi
             if [ "x$WARNFLAGS"      = "x" ]; then WARNFLAGS='-Wall'; fi
             PASS_TO_LINKER='-Wl,'
             ;;


### PR DESCRIPTION
on my (old) 32-bit mac with gcc 4.9.1/mpich from homebrew, i got the following compile time error:

/usr/include/sys/ucred.h:91:2: error: 'u_long' does not name a type
  u_long cr_ref;   /* reference count */
  ^
/usr/include/sys/ucred.h:133:9: error: 'u_int' does not name a type
         u_int   cr_version;             /* structure layout version */
         ^

adding the flag solves the problem.