### PR TITLE
Fixed configure and compile errors on BG/Q

### DIFF
--- a/configure
+++ b/configure
@@ -333,8 +333,8 @@ elif (hostname | grep 'vesta\|mira\|cetus\|seq'); then
   LDFLAGS="-L$BGQ_ESSL/lib64 -L$IBM_MAIN_DIR/xlf/bg/14.1/bglib64/ -L$IBM_MAIN_DIR/xlsmp/bg/3.1/bglib64/ -L$IBM_MAIN_DIR/xlmass/bg/7.3/bglib64/"
   INCLUDES="-I$BGQ_ESSL/include"
   AR='ar'
-  CXX=mpixlcxx_r
-  CXXFLAGS='-qsmp=omp -g -O3 -qarch=qp -qtune=qp -qsimd=auto -qhot=level=1 -qprefetch -qunroll=yes -qreport'
+  CXX=mpic++11
+  CXXFLAGS='-O3 -std=c++11 -fopenmp'
   DEFS='-DBGQ -D_POSIX_C_SOURCE=200112L -D__STDC_LIMIT_MACROS'
   WARNFLAGS=''
 

--- a/configure
+++ b/configure
@@ -327,10 +327,10 @@ elif (hostname | grep 'vesta\|mira\|cetus\|seq'); then
   echo 'Hostname recognized as a BG/Q machine.'
  
   host=bgq
-  SCALAPACKLIBS="-L/soft/libraries/alcf/current/xl/SCALAPACK/lib/ -lscalapack"
-  BLASLIBS="-L/soft/libraries/alcf/current/xl/LAPACK/lib/ -llapack -lgfortran -lesslsmpbg -lxlsmp -lxlfmath -lxlf90_r -lm -Wl,--allow-multiple-definition"
   BGQ_ESSL='/soft/libraries/essl/current'
-  LDFLAGS="-L$BGQ_ESSL/lib64 -L$IBM_MAIN_DIR/xlf/bg/14.1/bglib64/ -L$IBM_MAIN_DIR/xlsmp/bg/3.1/bglib64/ -L$IBM_MAIN_DIR/xlmass/bg/7.3/bglib64/"
+  SCALAPACKLIBS="-L/soft/libraries/alcf/current/xl/SCALAPACK/lib/ -lscalapack"
+  BLASLIBS="-L/soft/libraries/alcf/current/xl/LAPACK/lib/ -llapack -lgfortran -L${BGQ_ESSL}/lib64 -lesslsmpbg -L${IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp -L${IBM_MAIN_DIR}/xlf/bg/14.1/lib64 -lxlopt -lxlf90_r -lxlfmath -lxl -Wl,--allow-multiple-definition"
+  LDFLAGS=""
   INCLUDES="-I$BGQ_ESSL/include"
   AR='ar'
   CXX=mpic++11

--- a/src/shared/memcontrol.cxx
+++ b/src/shared/memcontrol.cxx
@@ -511,12 +511,12 @@ namespace CTF_int {
    * \brief gives total memory size per MPI process 
    */
   int64_t proc_bytes_total() {
-    int64_t total;
+    uint64_t total;
     int node_config;
 
     Kernel_GetMemorySize(KERNEL_MEMSIZE_HEAP, &total);
     if (mem_size > 0){
-      return MIN(total,mem_size);
+      return MIN(total,uint64_t(mem_size));
     } else {
       return total;
     }
@@ -526,8 +526,8 @@ namespace CTF_int {
    * \brief gives total memory available on this MPI process 
    */
   int64_t proc_bytes_available(){
-    int64_t mem_avail;
-    Kernel_GetMemorySize(KERNEL_MEMSIZE_HEAPAVAIL, &mem_avail); 
+    uint64_t mem_avail;
+    Kernel_GetMemorySize(KERNEL_MEMSIZE_HEAPAVAIL, &mem_avail);
     mem_avail*= memcap;
     mem_avail += mst_buffer_size-mst_buffer_used;
   /*  printf("HEAPAVIL = %llu, TOTAL HEAP - mallinfo used = %llu\n",


### PR DESCRIPTION
- Configure on Mira/Cetus now uses clang (XL does not work since C++11 is required).
- Updated BLAS flags for Mira.
- Fixed a type issue in proc_bytes_total() and proc_bytes_available() on BG/Q.