### PR TITLE
Enhancements for configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 include config.mk
 
-all: foo ./lib/libctf.a
-
-foo:
-	echo vpath $(VPATH)
+all: ./lib/libctf.a
 
 EXAMPLES = dft dft_3D gemm gemm_4D scalar trace weigh_4D subworld_gemm \
            permute_multiworld strassen slice_gemm ccsd sparse_permuted_slice 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 include config.mk
 
-all: ./lib/libctf.a
+all: foo ./lib/libctf.a
+
+foo:
+	echo vpath $(VPATH)
 
 EXAMPLES = dft dft_3D gemm gemm_4D scalar trace weigh_4D subworld_gemm \
            permute_multiworld strassen slice_gemm ccsd sparse_permuted_slice 
@@ -48,7 +51,7 @@ ctf:
 ctflib: ctf 
 	$(AR) -crs ./lib/libctf.a src/*/*.o; 
 
-lib/libctf.a: src/*/*.cxx src/*/*.h Makefile src/Makefile src/*/Makefile config.mk
+lib/libctf.a: $(SRCDIR)/src/*/*.cxx $(SRCDIR)/src/*/*.h Makefile src/Makefile src/*/Makefile config.mk
 	$(MAKE) ctflib
 	
 clean: clean_bin clean_lib

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -15,8 +15,8 @@ else
 endif
 
 
-../bin/%: %.cxx ../lib/libctf.a
-	$(FCXX) $< -o $@ -I../include/ -L../lib -lctf $(LIBS)
+../bin/%: $(SRCDIR)/%.cxx ../lib/libctf.a
+	$(FCXX) $< -o $@ -I$(SRCDIR)/../include/ -L../lib -lctf $(LIBS)
 
 clean: 
 	rm -f $(OBJS) 

--- a/configure
+++ b/configure
@@ -217,18 +217,35 @@ function check_if_apple
   status=1
   cat > .test.cxx <<EOF
 #if defined(__APPLE__)
-  int main(){  return 1; }
-#else
-  int main(){  return 0; }
+#error
 #endif
+  int main(){  return 0; }
 EOF
   $CXX $DEFS $WARNFLAGS $CXXFLAGS $INCLUDES .test.cxx $LDFLAGS  > /dev/null 2>&1
-  ./a.out;
-  status=$?
+  if [ -x a.out ]; then
+    status=0
+  fi
   rm -f .test.cxx a.out
   return $status
 }
 
+function link_makefiles
+{
+	local srcdir=$1
+	local builddir=$2
+	
+	if [ -f $srcdir/Makefile ]; then
+		mkdir -p $builddir
+		if [ ! -e $builddir/Makefile ]; then
+			ln -s $srcdir/Makefile $builddir/Makefile
+		fi
+		for subdir in `ls -1 $srcdir`; do
+			if [ -d $srcdir/$subdir ]; then
+				link_makefiles $srcdir/$subdir $builddir/$subdir
+			fi
+		done
+	fi
+}
 
 PARAMS=$0
 for PARAM in "$@"
@@ -526,6 +543,21 @@ else
   echo 'NVCC provided and cuda will be used.'
 fi
 
+#
+# Set up file structure for out-of-tree build
+#
+builddir=`pwd`
+srcdir=`dirname $0`
+if [[ $srcdir != /* ]]; then
+	srcdir=`cd $builddir/$srcdir;pwd`
+fi
+if [ $builddir != $srcdir ]; then
+	echo "Copying directory structure from $srcdir."
+	link_makefiles $srcdir $builddir
+fi
+mkdir -p lib
+mkdir -p bin
+
 cat > config.mk <<EOF
 BLAS_LIBS   = $SCALAPACKLIBS $BLASLIBS
 
@@ -550,6 +582,12 @@ FCXX        = \$(CXX) \$(CXXFLAGS) \$(DEFS) \$(INCLUDES)
 LIBS        = \$(BLAS_LIBS) \$(LDFLAGS)
 
 OFFLOAD_CXX = $NVCC $NVCCFLAGS \$(DEFS) \$(INCLUDES)
+
+BASE_BUILDDIR   = $builddir
+BASE_SRCDIR     = $srcdir
+
+BUILDDIR   = \$(shell pwd)
+SRCDIR     = \$(subst \$(BASE_BUILDDIR),\$(BASE_SRCDIR),\$(BUILDDIR))
 
 EOF
 

--- a/configure
+++ b/configure
@@ -554,6 +554,9 @@ fi
 if [ $builddir != $srcdir ]; then
 	echo "Copying directory structure from $srcdir."
 	link_makefiles $srcdir $builddir
+	if [ ! -e include ]; then
+		ln -s $srcdir/include include
+	fi
 fi
 mkdir -p lib
 mkdir -p bin

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -8,8 +8,8 @@ EXAMPLES = dft dft_3D gemm gemm_4D scalar trace weigh_4D subworld_gemm \
 #.PHONY: $(EXAMPLES)
 $(EXAMPLES): %:  ../bin/%
 
-../bin/%: %.cxx ../lib/libctf.a
-	$(FCXX) $< -o $@ -I../include/ -L../lib -lctf $(LIBS)
+../bin/%: $(SRCDIR)/%.cxx ../lib/libctf.a
+	$(FCXX) $< -o $@ -I$(SRCDIR)/../include/ -L../lib -lctf $(LIBS)
 
 
 

--- a/src/contraction/Makefile
+++ b/src/contraction/Makefile
@@ -3,11 +3,18 @@ include ../../config.mk
 OBJS = contraction.o sym_seq_ctr.o ctr_offload.o ctr_comm.o ctr_tsr.o ctr_2d_general.o
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
-HDRS = ../../Makefile ../../config.mk  ../interface/functions.h ../mapping/distribution.h ../mapping/mapping.h ../redistribution/nosym_transp.h ../redistribution/redist.h ../scaling/strp_tsr.h ../shared/iter_tsr.h ../shared/memcontrol.h ../shared/offload.h ../shared/util.h ../symmetry/sym_indices.h ../symmetry/symmetrization.h ../tensor/algstrct.h ../tensor/untyped_tensor.h
+HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../interface/functions.h \
+		$(SRCDIR)/../mapping/distribution.h $(SRCDIR)/../mapping/mapping.h \
+		$(SRCDIR)/../redistribution/nosym_transp.h $(SRCDIR)/../redistribution/redist.h \
+		$(SRCDIR)/../scaling/strp_tsr.h $(SRCDIR)/../shared/iter_tsr.h \
+		$(SRCDIR)/../shared/memcontrol.h $(SRCDIR)/../shared/offload.h \
+		$(SRCDIR)/../shared/util.h $(SRCDIR)/../symmetry/sym_indices.h \
+		$(SRCDIR)/../symmetry/symmetrization.h $(SRCDIR)/../tensor/algstrct.h \
+		$(SRCDIR)/../tensor/untyped_tensor.h
 
 ctf: $(OBJS) 
 
-$(OBJS): %.o: %.cxx *.h $(HDRS)
+$(OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h $(HDRS)
 	$(FCXX) -c $<
 
 

--- a/src/interface/Makefile
+++ b/src/interface/Makefile
@@ -5,12 +5,19 @@ OBJS = common.o  flop_counter.o world.o idx_tensor.o term.o schedule.o semiring.
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
 HDRS = ../../Makefile ../../config.mk 
 
-ctf: $(OBJS) 
+ctf: foo $(OBJS) 
+
+foo:
+	echo $(VPATH)
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
-HDRS = ../../Makefile ../../config.mk  ../contraction/contraction.h ../interface/common.h ../mapping/topology.h ../scaling/scaling.h ../shared/memcontrol.h ../shared/util.h ../summation/summation.h ../tensor/algstrct.h ../tensor/untyped_tensor.h 
+HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../contraction/contraction.h \
+		$(SRCDIR)/../interface/common.h $(SRCDIR)/../mapping/topology.h \
+		$(SRCDIR)/../scaling/scaling.h $(SRCDIR)/../shared/memcontrol.h \
+		$(SRCDIR)/../shared/util.h $(SRCDIR)/../summation/summation.h \
+		$(SRCDIR)/../tensor/algstrct.h $(SRCDIR)/../tensor/untyped_tensor.h 
 
-$(OBJS): %.o: %.cxx *.h  $(HDRS)
+$(OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h  $(HDRS)
 	$(FCXX) -c $<
 
 clean: 

--- a/src/interface/Makefile
+++ b/src/interface/Makefile
@@ -5,10 +5,7 @@ OBJS = common.o  flop_counter.o world.o idx_tensor.o term.o schedule.o semiring.
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
 HDRS = ../../Makefile ../../config.mk 
 
-ctf: foo $(OBJS) 
-
-foo:
-	echo $(VPATH)
+ctf: $(OBJS) 
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
 HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../contraction/contraction.h \

--- a/src/mapping/Makefile
+++ b/src/mapping/Makefile
@@ -5,9 +5,11 @@ OBJS = mapping.o distribution.o topology.o
 ctf: $(OBJS) 
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
-HDRS = ../../Makefile ../../config.mk  ../interface/common.h ../mapping/mapping.h ../shared/util.h ../summation/sum_tsr.h ../tensor/untyped_tensor.h 
+HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../interface/common.h \
+		$(SRCDIR)/../mapping/mapping.h $(SRCDIR)/../shared/util.h \
+		$(SRCDIR)/../summation/sum_tsr.h $(SRCDIR)/../tensor/untyped_tensor.h 
 
-$(OBJS): %.o: %.cxx *.h $(HDRS)
+$(OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h $(HDRS)
 	$(FCXX) -c $<
 
 

--- a/src/redistribution/Makefile
+++ b/src/redistribution/Makefile
@@ -5,9 +5,10 @@ OBJS = redist.o sparse_rw.o pad.o nosym_transp.o cyclic_reshuffle.o glb_cyclic_r
 ctf: $(OBJS) 
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
-HDRS = ../../Makefile ../../config.mk  ../mapping/distribution.h ../shared/util.h ../tensor/algstrct.h
+HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../mapping/distribution.h \
+		$(SRCDIR)/../shared/util.h $(SRCDIR)/../tensor/algstrct.h
 
-$(OBJS): %.o: %.cxx *.h $(HDRS)
+$(OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h $(HDRS)
 	$(FCXX) -c $<
 
 

--- a/src/scaling/Makefile
+++ b/src/scaling/Makefile
@@ -5,9 +5,14 @@ OBJS = scaling.o sym_seq_scl.o scale_tsr.o strp_tsr.o
 ctf: $(OBJS) 
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
-HDRS = ../../Makefile ../../config.mk  ../contraction/ctr_comm.h ../interface/common.h ../mapping/distribution.h ../mapping/mapping.h ../scaling/scale_tsr.h ../shared/iter_tsr.h ../shared/memcontrol.h ../shared/util.h ../summation/sum_tsr.h ../tensor/algstrct.h ../tensor/untyped_tensor.h
+HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../contraction/ctr_comm.h \
+		$(SRCDIR)/../interface/common.h $(SRCDIR)/../mapping/distribution.h \
+		$(SRCDIR)/../mapping/mapping.h $(SRCDIR)/../scaling/scale_tsr.h \
+		$(SRCDIR)/../shared/iter_tsr.h $(SRCDIR)/../shared/memcontrol.h \
+		$(SRCDIR)/../shared/util.h $(SRCDIR)/../summation/sum_tsr.h \
+		$(SRCDIR)/../tensor/algstrct.h $(SRCDIR)/../tensor/untyped_tensor.h
 
-$(OBJS): %.o: %.cxx *.h $(HDRS)
+$(OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h $(HDRS)
 	$(FCXX) -c $<
 
 

--- a/src/shared/Makefile
+++ b/src/shared/Makefile
@@ -4,16 +4,16 @@ include ../../config.mk
 OBJS = util.o memcontrol.o int_timer.o
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
-HDRS = ../../Makefile ../../config.mk  ../interface/common.h ../interface/timer.h
+HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../interface/common.h $(SRCDIR)/../interface/timer.h
 
 NVCC_OBJS = offload.o
 
 ctf: $(OBJS) 
 
-$(OBJS): %.o: %.cxx *.h $(HDRS)
+$(OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h $(HDRS)
 	$(FCXX) -c $<
 
-$(NVCC_OBJS): %.o: %.cxx *.h
+$(NVCC_OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h
 	$(OFFLOAD_CXX) -c $<
 
 clean: 

--- a/src/summation/Makefile
+++ b/src/summation/Makefile
@@ -3,11 +3,17 @@ include ../../config.mk
 OBJS = summation.o sym_seq_sum.o sum_tsr.o 
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
-HDRS = ../../Makefile ../../config.mk  ../mapping/distribution.h ../mapping/mapping.h ../redistribution/nosym_transp.h ../redistribution/redist.h ../scaling/scaling.h ../scaling/strp_tsr.h ../shared/iter_tsr.h ../shared/memcontrol.h ../shared/util.h ../symmetry/sym_indices.h ../symmetry/symmetrization.h ../tensor/algstrct.h ../tensor/untyped_tensor.h 
+HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../mapping/distribution.h \
+		$(SRCDIR)/../mapping/mapping.h $(SRCDIR)/../redistribution/nosym_transp.h \
+		$(SRCDIR)/../redistribution/redist.h $(SRCDIR)/../scaling/scaling.h \
+		$(SRCDIR)/../scaling/strp_tsr.h $(SRCDIR)/../shared/iter_tsr.h \
+		$(SRCDIR)/../shared/memcontrol.h $(SRCDIR)/../shared/util.h \
+		$(SRCDIR)/../symmetry/sym_indices.h $(SRCDIR)/../symmetry/symmetrization.h \
+		$(SRCDIR)/../tensor/algstrct.h $(SRCDIR)/../tensor/untyped_tensor.h 
 
 ctf: $(OBJS) 
 
-$(OBJS): %.o: %.cxx *.h $(HDRS)
+$(OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h $(HDRS)
 	$(FCXX) -c $<
 
 

--- a/src/symmetry/Makefile
+++ b/src/symmetry/Makefile
@@ -3,11 +3,14 @@ include ../../config.mk
 OBJS = sym_indices.o symmetrization.o
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
-HDRS = ../../Makefile ../../config.mk  ../contraction/contraction.h ../interface/common.h ../interface/timer.h ../shared/util.h ../summation/summation.h ../tensor/untyped_tensor.h
+HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../contraction/contraction.h \
+		$(SRCDIR)/../interface/common.h $(SRCDIR)/../interface/timer.h \
+		$(SRCDIR)/../shared/util.h $(SRCDIR)/../summation/summation.h \
+		$(SRCDIR)/../tensor/untyped_tensor.h
 
 ctf: $(OBJS) 
 
-$(OBJS): %.o: %.cxx *.h $(HDRS)
+$(OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h $(HDRS)
 	$(FCXX) -c $<
 
 

--- a/src/tensor/Makefile
+++ b/src/tensor/Makefile
@@ -3,12 +3,18 @@ include ../../config.mk
 OBJS = untyped_tensor.o algstrct.o
 
 #%d | r ! grep -ho "\.\..*\.h" *.cxx *.h | sort | uniq
-HDRS = ../../Makefile ../../config.mk  ../interface/common.h ../interface/idx_tensor.h ../interface/timer.h ../interface/world.h ../mapping/distribution.h ../mapping/mapping.h ../redistribution/nosym_transp.h ../redistribution/pad.h ../redistribution/redist.h ../redistribution/sparse_rw.h ../shared/memcontrol.h ../shared/util.h ../summation/summation.h
+HDRS = ../../Makefile ../../config.mk  $(SRCDIR)/../interface/common.h \
+		$(SRCDIR)/../interface/idx_tensor.h $(SRCDIR)/../interface/timer.h \
+		$(SRCDIR)/../interface/world.h $(SRCDIR)/../mapping/distribution.h \
+		$(SRCDIR)/../mapping/mapping.h $(SRCDIR)/../redistribution/nosym_transp.h \
+		$(SRCDIR)/../redistribution/pad.h $(SRCDIR)/../redistribution/redist.h \
+		$(SRCDIR)/../redistribution/sparse_rw.h $(SRCDIR)/../shared/memcontrol.h \
+		$(SRCDIR)/../shared/util.h $(SRCDIR)/../summation/summation.h
 
 
 ctf: $(OBJS) 
 
-$(OBJS): %.o: %.cxx *.h $(HDRS)
+$(OBJS): %.o: $(SRCDIR)/%.cxx $(SRCDIR)/*.h $(HDRS)
 	$(FCXX) -c $<
 
 

--- a/studies/Makefile
+++ b/studies/Makefile
@@ -5,8 +5,8 @@ STUDIES = fast_diagram fast_3mm fast_sym fast_sym_4D fast_tensor_ctr fast_sy_as_
 .PHONY: $(STUDIES)
 $(STUDIES): %:  ../bin/%
 
-../bin/%: %.cxx ../lib/libctf.a
-	$(FCXX) $< -o $@ -I../include/ -L../lib -lctf $(LIBS)
+../bin/%: $(SRCDIR)/%.cxx ../lib/libctf.a
+	$(FCXX) $< -o $@ -I$(SRCDIR)/../include/ -L../lib -lctf $(LIBS)
 
 clean: 
 	rm -f $(OBJS) 

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,8 +16,8 @@ else
 	@echo 'cannot build $@ without ScaLAPACK';
 endif
 
-../bin/%: %.cxx ../lib/libctf.a ../examples/*.cxx *.cxx Makefile ../Makefile 
-	$(FCXX) $< -o $@ -I../include/ -L../lib -lctf $(LIBS)
+../bin/%: $(SRCDIR)/%.cxx ../lib/libctf.a $(SRCDIR)/../examples/*.cxx $(SRCDIR)/*.cxx Makefile ../Makefile 
+	$(FCXX) $< -o $@ -I$(SRCDIR)/../include/ -L../lib -lctf $(LIBS)
 
 clean: 
 	rm -f $(OBJS) 


### PR DESCRIPTION
1) I changed the test for the __APPLE__ macro to a compile-only check using #error, which is slightly friendlier than actually running the compiled program.

2) I added out-of-tree build capability. For example:

git checkout ... ctf
mkdir build
cd build
../ctf/configure
make

I tested that everything still works in-tree as well.