### PR TITLE
move omp.h include outside of CTF_int namespace

### DIFF
--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -52,6 +52,13 @@ namespace CTF_int {
 #include "pmpi.h"
 #include "fompi_wrapper.h"
 
+#ifndef __APPLE__
+#ifndef OMP_OFF
+#define USE_OMP
+#include "omp.h"
+#endif
+#endif
+
 namespace CTF_int {
 
 
@@ -125,13 +132,6 @@ namespace CTF_int {
         break; \
     }
 
-
-  #ifndef __APPLE__
-  #ifndef OMP_OFF
-  #define USE_OMP
-  #include "omp.h"
-  #endif
-  #endif
 
   #define CTF_COUNT_FLOPS
   #ifdef CTF_COUNT_FLOPS


### PR DESCRIPTION
This is the smallest fix for https://github.com/solomonik/ctf/issues/27